### PR TITLE
Use the synchronous pwm methods when moving a servo

### DIFF
--- a/lib/servo.js
+++ b/lib/servo.js
@@ -89,8 +89,8 @@ module.exports = function Servo(opts) {
     posspec.validate({ pos }, errHdlr);
     const count = minCount + ((pos / 100) * (maxCount - minCount));
 
-    options.pwm.setPWMFreq(options.freq);
-    options.pwm.setPWM(options.pin, 0, count);
+    options.pwm.setPWMFreqSync(options.freq);
+    options.pwm.setPWMSync(options.pin, 0, count);
     debug(`moveTo(): Moved servolib to position ${pos}% = ${count} counts.`);
   };
 

--- a/test/servo.js
+++ b/test/servo.js
@@ -6,8 +6,10 @@ const sinon = require('sinon');
 const servo = require('../lib/servo.js');
 
 const pwm = {
-  setPWM: sinon.spy(),
-  setPWMFreq: sinon.spy(),
+  setPWM: sinon.stub().yieldsAsync(null),
+  setPWMFreq: sinon.stub().yieldsAsync(null),
+  setPWMSync: sinon.spy(),
+  setPWMFreqSync: sinon.spy(),
 };
 
 describe('lib/servolib.js', () => {

--- a/test/servo.js
+++ b/test/servo.js
@@ -70,22 +70,22 @@ describe('lib/servolib.js', () => {
 
     it('should set PWM freq on move', () => {
       inst.moveTo(0);
-      pwm.setPWMFreq.should.be.calledWith(defFreq);
+      pwm.setPWMFreqSync.should.be.calledWith(defFreq);
     });
 
     it('should move to 0', () => {
       inst.moveTo(0);
-      pwm.setPWM.should.be.calledWith(0, 0, defMinCount);
+      pwm.setPWMSync.should.be.calledWith(0, 0, defMinCount);
     });
 
     it('should move to 100', () => {
       inst.moveTo(100);
-      pwm.setPWM.should.be.calledWith(0, 0, defMaxCount);
+      pwm.setPWMSync.should.be.calledWith(0, 0, defMaxCount);
     });
 
     it('should move to 50', () => {
       inst.moveTo(50);
-      pwm.setPWM.should.be.calledWith(0, 0, (defMaxCount + defMinCount) / 2);
+      pwm.setPWMSync.should.be.calledWith(0, 0, (defMaxCount + defMinCount) / 2);
     });
   });
 
@@ -102,22 +102,22 @@ describe('lib/servolib.js', () => {
 
     it('should set PWM freq on move with the new params', () => {
       inst.moveTo(0);
-      pwm.setPWMFreq.should.be.calledWith(newFreq);
+      pwm.setPWMFreqSync.should.be.calledWith(newFreq);
     });
 
     it('should move to 0 with the new params', () => {
       inst.moveTo(0);
-      pwm.setPWM.should.be.calledWith(0, 0, newMinCount);
+      pwm.setPWMSync.should.be.calledWith(0, 0, newMinCount);
     });
 
     it('should move to 100 with the new params', () => {
       inst.moveTo(100);
-      pwm.setPWM.should.be.calledWith(0, 0, newMaxCount);
+      pwm.setPWMSync.should.be.calledWith(0, 0, newMaxCount);
     });
 
     it('should move to 50 with the new params', () => {
       inst.moveTo(50);
-      pwm.setPWM.should.be.calledWith(0, 0, (newMaxCount + newMinCount) / 2);
+      pwm.setPWMSync.should.be.calledWith(0, 0, (newMaxCount + newMinCount) / 2);
     });
   });
 });


### PR DESCRIPTION
Current implementation crash when moveTo is called. This fixes the issue by using the synchronous methods for setting the pwm frequency and syncing.